### PR TITLE
♻️refactor : 로그인 기능의 api를 고객과 판매자가 통합하여 사용할 수 있도록 수정 

### DIFF
--- a/src/main/java/com/project/openmarket/domain/auth/domain/enums/Role.java
+++ b/src/main/java/com/project/openmarket/domain/auth/domain/enums/Role.java
@@ -1,0 +1,27 @@
+package com.project.openmarket.domain.auth.domain.enums;
+
+import java.util.Arrays;
+
+import lombok.Getter;
+
+public enum Role {
+	EMPTY("empty","없음"),
+	SELLER("seller","판매자"),
+	CONSUMER("consumer", "고객");
+	@Getter
+	private final String key;
+	private final String value;
+
+	Role(String key, String value){
+		this.key = key;
+		this.value = value;
+	}
+
+	public static Role findRoleByKey(String key){
+		return Arrays.stream(values())
+			.filter(role ->role.getKey().equals(key))
+			.findAny()
+			.orElse(EMPTY);
+	}
+
+}

--- a/src/main/java/com/project/openmarket/domain/user/controller/ConsumerController.java
+++ b/src/main/java/com/project/openmarket/domain/user/controller/ConsumerController.java
@@ -6,10 +6,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.project.openmarket.domain.user.dto.reposne.ConsumerResponseDto;
 import com.project.openmarket.domain.user.dto.reposne.UserResponseDto;
 import com.project.openmarket.domain.user.dto.request.ConsumerCreateReqestDto;
-import com.project.openmarket.domain.user.dto.request.ConsumerLoginRequestDto;
 import com.project.openmarket.domain.user.service.ConsumerService;
 
 import lombok.RequiredArgsConstructor;
@@ -21,15 +19,9 @@ public class ConsumerController {
 	private final ConsumerService consumerService;
 
 	@PostMapping("/consumer")
-	public ResponseEntity<UserResponseDto> saveConsumer(@RequestBody ConsumerCreateReqestDto requestDto){
-		UserResponseDto responseDto = consumerService.saveConumser(requestDto);
+	public ResponseEntity<UserResponseDto> signup(@RequestBody ConsumerCreateReqestDto requestDto){
+		UserResponseDto responseDto = consumerService.signup(requestDto);
 		return ResponseEntity.ok().body(responseDto);
-	}
-
-	@PostMapping("/consumer/login")
-	public ResponseEntity<ConsumerResponseDto> login(@RequestBody ConsumerLoginRequestDto requestDto){
-		ConsumerResponseDto consumerResponseDto = consumerService.login(requestDto);
-		return ResponseEntity.ok().body(consumerResponseDto);
 	}
 }
 

--- a/src/main/java/com/project/openmarket/domain/user/controller/UserController.java
+++ b/src/main/java/com/project/openmarket/domain/user/controller/UserController.java
@@ -1,0 +1,38 @@
+package com.project.openmarket.domain.user.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.project.openmarket.domain.auth.domain.enums.Role;
+import com.project.openmarket.domain.user.dto.reposne.UserResponseDto;
+import com.project.openmarket.domain.user.dto.request.LoginRequestDto;
+import com.project.openmarket.domain.user.service.ConsumerService;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class UserController {
+	private final ConsumerService consumerService;
+
+	@PostMapping("/login")
+	public ResponseEntity<UserResponseDto> login(
+		@RequestParam("role") String role,
+		@RequestBody LoginRequestDto requestDto,
+		HttpServletRequest request){
+		Role rl =  Role.findRoleByKey(role);
+
+		UserResponseDto userResponseDto = null;
+
+		if(rl.equals(Role.CONSUMER)){
+			userResponseDto = consumerService.login(requestDto);
+		}
+		return ResponseEntity.ok().body(userResponseDto);
+	}
+}

--- a/src/main/java/com/project/openmarket/domain/user/dto/request/LoginRequestDto.java
+++ b/src/main/java/com/project/openmarket/domain/user/dto/request/LoginRequestDto.java
@@ -4,10 +4,10 @@ import com.project.openmarket.validator.Validator;
 
 import jakarta.validation.constraints.NotEmpty;
 
-public record ConsumerLoginRequestDto(
+public record LoginRequestDto(
 	@NotEmpty String email,
 	@NotEmpty String password) {
-	public ConsumerLoginRequestDto {
+	public LoginRequestDto {
 		Validator.validateEmail(email);
 	}
 }

--- a/src/main/java/com/project/openmarket/domain/user/entity/User.java
+++ b/src/main/java/com/project/openmarket/domain/user/entity/User.java
@@ -40,4 +40,8 @@ public abstract class User {
 		this.phoneNumber = phoneNumber;
 		this.password = password;
 	}
+
+	public boolean isSamePassword(String another){
+		return password.equals(another);
+	}
 }

--- a/src/main/java/com/project/openmarket/domain/user/service/ConsumerService.java
+++ b/src/main/java/com/project/openmarket/domain/user/service/ConsumerService.java
@@ -3,10 +3,9 @@ package com.project.openmarket.domain.user.service;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.project.openmarket.domain.user.dto.reposne.ConsumerResponseDto;
 import com.project.openmarket.domain.user.dto.reposne.UserResponseDto;
 import com.project.openmarket.domain.user.dto.request.ConsumerCreateReqestDto;
-import com.project.openmarket.domain.user.dto.request.ConsumerLoginRequestDto;
+import com.project.openmarket.domain.user.dto.request.LoginRequestDto;
 import com.project.openmarket.domain.user.entity.Consumer;
 import com.project.openmarket.domain.user.repository.ConsumerRepository;
 
@@ -18,7 +17,7 @@ public class ConsumerService {
 	private final ConsumerRepository consumerRepository;
 
 	@Transactional
-	public UserResponseDto saveConumser(ConsumerCreateReqestDto request){
+	public UserResponseDto signup(ConsumerCreateReqestDto request){
 		Consumer consumer = request.toEntity();
 		duplicatedEmail(consumer.getEmail());
 		return UserResponseDto.of(consumerRepository.save(consumer));
@@ -32,8 +31,8 @@ public class ConsumerService {
 	}
 
 	@Transactional
-	public ConsumerResponseDto login(ConsumerLoginRequestDto request){
-		return ConsumerResponseDto.of(login(request.email(),request.password()));
+	public UserResponseDto login(LoginRequestDto request){
+		return UserResponseDto.of(login(request.email(),request.password()));
 	}
 
 	private Consumer login(String email, String password){

--- a/src/main/java/com/project/openmarket/domain/user/service/ConsumerService.java
+++ b/src/main/java/com/project/openmarket/domain/user/service/ConsumerService.java
@@ -33,15 +33,12 @@ public class ConsumerService {
 
 	@Transactional
 	public ConsumerResponseDto login(ConsumerLoginRequestDto request){
+		return ConsumerResponseDto.of(login(request.email(),request.password()));
+	}
 
-		Consumer consumer = consumerRepository.findByEmail(request.email())
+	private Consumer login(String email, String password){
+		return consumerRepository.findByEmail(email)
+			.filter(m -> m.isSamePassword(password))
 			.orElseThrow(() -> new IllegalArgumentException());
-
-		System.out.println(request.email() + " "+request.password()+" "+consumer.toString());
-		if(!request.password().equals(consumer.getPassword())){
-			throw new IllegalArgumentException();
-		}
-
-		return ConsumerResponseDto.of(consumer);
 	}
 }

--- a/src/test/java/com/project/openmarket/consmer/ConsumerServiceTest.java
+++ b/src/test/java/com/project/openmarket/consmer/ConsumerServiceTest.java
@@ -16,7 +16,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.project.openmarket.domain.user.dto.request.ConsumerCreateReqestDto;
-import com.project.openmarket.domain.user.dto.request.ConsumerLoginRequestDto;
+import com.project.openmarket.domain.user.dto.request.LoginRequestDto;
 import com.project.openmarket.domain.user.entity.Consumer;
 import com.project.openmarket.domain.user.repository.ConsumerRepository;
 import com.project.openmarket.domain.user.service.ConsumerService;
@@ -28,6 +28,7 @@ class ConsumerServiceTest {
 	private ConsumerService consumerService;
 	@Mock
 	private ConsumerRepository consumerRepository;
+
 	@Test
 	@Order(1)
 	@DisplayName("고객등록_테스트")
@@ -36,7 +37,7 @@ class ConsumerServiceTest {
 		final var request = createConsumer();
  		//when
 		when(consumerRepository.save(any(Consumer.class))).thenReturn(request.toEntity());
-		final var response = consumerService.saveConumser(request);
+		final var response = consumerService.signup(request);
 
 		//then
 		assertThat(request.email())
@@ -45,13 +46,13 @@ class ConsumerServiceTest {
 
 	@Test
 	@Order(2)
-	@DisplayName("고객등록_이메일중복_테스트")
+	@DisplayName("고객등록_이메일중복_테스트시_예외가_발생한다")
 	void sinupByDuplicatedEmail(){
 		final var request = new ConsumerCreateReqestDto("asdf3@example.com","dd","010-0000-0000","1234","");
 
 		// when
 		when(consumerRepository.existsByEmail(request.email())).thenReturn(true);
-		Throwable thrown = catchThrowable(() -> consumerService.saveConumser(request));
+		Throwable thrown = catchThrowable(() -> consumerService.signup(request));
 
 		//then
 		assertThat(thrown)
@@ -60,7 +61,7 @@ class ConsumerServiceTest {
 
 	@Test
 	@Order(2)
-	@DisplayName("고객등록_이메일_없이_테스트")
+	@DisplayName("고객등록_이메일_없이_테스트시_예외가_발생한다")
 	void sinupByEmptyEmail(){
 		//given
 		String email = "";
@@ -74,7 +75,7 @@ class ConsumerServiceTest {
 
 	@Test
 	@Order(2)
-	@DisplayName("고객등록_모두_빈값_테스트")
+	@DisplayName("고객등록_모두_빈값_테스트시_예외가_발생한다")
 	void sinupByAllEmptyInfo(){
 		// when
 		Throwable thrown = catchThrowable(() -> new ConsumerCreateReqestDto("","","","",""));
@@ -102,13 +103,13 @@ class ConsumerServiceTest {
 
 	@Test
 	@Order(4)
-	@DisplayName("고객_없는_이메일_로그인_실패_테스트")
+	@DisplayName("고객_없는_이메일_로그인_테스트시_예외가_발생한다")
 	void loginByWrongEmail(){
 		//given
-		final var request = new ConsumerLoginRequestDto("test@example.com", "1234");
+		final var request = new LoginRequestDto("test@example.com", "1234");
 
 		// when
-		when(consumerRepository.findByEmail(request.email())).thenReturn(Optional.empty());
+		when(consumerRepository.findByEmail(any(String.class))).thenReturn(Optional.empty());
 		Throwable thrown = catchThrowable(() -> consumerService.login(request));
 
 		//then
@@ -117,10 +118,10 @@ class ConsumerServiceTest {
 	}
 
 	@Test
-	@DisplayName("고객_로그인_틀린_패스워드_테스트")
+	@DisplayName("고객_로그인_틀린_패스워드_테스트시_예외가_발생한다")
 	void loginByWrongPassword(){
 		//given
-		final var request = new ConsumerLoginRequestDto("asdf3@example.com", "12345");
+		final var request = new LoginRequestDto("asdf3@example.com", "12345");
 
 		// when
 		Throwable thrown = catchThrowable(() -> consumerService.login(request));
@@ -141,10 +142,10 @@ class ConsumerServiceTest {
 		return new ConsumerCreateReqestDto(email, name, phoneNumber, password, address);
 	}
 
-	private ConsumerLoginRequestDto createLogin(){
+	private LoginRequestDto createLogin(){
 		String email = "asdf3@example.com";
 		String password = "1234";
 
-		return new ConsumerLoginRequestDto(email, password);
+		return new LoginRequestDto(email, password);
 	}
 }

--- a/src/test/java/com/project/openmarket/consmer/ConsumerStep.java
+++ b/src/test/java/com/project/openmarket/consmer/ConsumerStep.java
@@ -1,15 +1,24 @@
 package com.project.openmarket.consmer;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpSession;
 
 import com.project.openmarket.domain.user.dto.request.ConsumerCreateReqestDto;
-import com.project.openmarket.domain.user.dto.request.ConsumerLoginRequestDto;
+import com.project.openmarket.domain.user.dto.request.LoginRequestDto;
 
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 
 public class ConsumerStep {
+
+	private MockHttpSession session;
+	@BeforeEach
+	void setUp() {
+		session = new MockHttpSession();
+	}
+
 	public static ExtractableResponse<Response> 고객생성요청(final ConsumerCreateReqestDto request) {
 		return RestAssured
 			.given().log().all()
@@ -30,20 +39,20 @@ public class ConsumerStep {
 		return new ConsumerCreateReqestDto(email, name, phoneNumber, password, address);
 	}
 
-	public static ExtractableResponse<Response> 로그인요청(final ConsumerLoginRequestDto request) {
+	public static ExtractableResponse<Response> 로그인요청(final LoginRequestDto request) {
 		return RestAssured
 			.given().log().all()
 			.contentType(MediaType.APPLICATION_JSON_VALUE)
 			.body(request)
 			.when()
-			.post("/api/v1/consumer/login")
+			.post("/api/v1/login?role=consumer")
 			.then()
 			.log().all().extract();
 	}
 
-	public static ConsumerLoginRequestDto 로그인요청_생성() {
+	public static LoginRequestDto 로그인요청_생성() {
 		String email = "asdf@example.com";
 		String password = "1234";
-		return new ConsumerLoginRequestDto(email, password);
+		return new LoginRequestDto(email, password);
 	}
 }


### PR DESCRIPTION
- `@RequestParam`을 통해 고객 로그인인지, 판매자 로그인인지 구분하여 요청을 받을 수 있도록 추가
- Role이라는 Enum을 추가하여 `@RequestParam`을 통해 들어온 값을 이용하여 판매자와 고객을 찾는 기능 추가
- 변경한 로그인 API에 따른 로그인 API테스트 코드 수정
- 기존 테스트 코드의 DisplayName을 결과에 대해서 상세하게 기술할 수 있도록 수정